### PR TITLE
Fixed Broken Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <h2 align="center">Background</h2>
 
-This plugin will build your [AWS SAM CLI](https://github.com/awslabs/aws-sam-cli) project using Webpack. You can use it to replace the `sam build` step if every function in your SAM template uses the `nodejs12.x`, `nodejs14.x` or `nodejs16.x` runtime. If your project uses other runtimes then look at [Building Apps with SAM, TypeScript and VS Code Debugging](http://www.goingserverless.com/blog/building-apps-with-sam-typescript-and-vscode-debugging).
+This plugin will build your [AWS SAM CLI](https://github.com/awslabs/aws-sam-cli) project using Webpack. You can use it to replace the `sam build` step if every function in your SAM template uses the `nodejs12.x`, `nodejs14.x` or `nodejs16.x` runtime. If your project uses other runtimes then look at [Building Apps with SAM, TypeScript and VS Code Debugging](https://www.goingserverless.com/blog/building-apps-with-sam-typescript-and-vs-code-debugging).
 
 I started this project for two reasons:
 


### PR DESCRIPTION
Note: the link seems to redirect to https://www.richdevelops.dev/blog/building-apps-with-sam-typescript-and-vs-code-debugging. In the spirit of minimal change though, all that seemed to be required was adding the dash between "vs" and "code". I also updated the protocol to https for good measure.

Perhaps though the link should just go directly to https://www.richdevelops.dev/blog/building-apps-with-sam-typescript-and-vs-code-debugging?