### PR TITLE
Remove nodejs12 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <h2 align="center">Background</h2>
 
-This plugin will build your [AWS SAM CLI](https://github.com/awslabs/aws-sam-cli) project using Webpack. You can use it to replace the `sam build` step if every function in your SAM template uses the `nodejs12.x`, `nodejs14.x` or `nodejs16.x` runtime. If your project uses other runtimes then look at [Building Apps with SAM, TypeScript and VS Code Debugging](http://www.goingserverless.com/blog/building-apps-with-sam-typescript-and-vscode-debugging).
+This plugin will build your [AWS SAM CLI](https://github.com/awslabs/aws-sam-cli) project using Webpack. You can use it to replace the `sam build` step if every function in your SAM template uses the `nodejs14.x` or `nodejs16.x` runtime. If your project uses other runtimes then look at [Building Apps with SAM, TypeScript and VS Code Debugging](http://www.goingserverless.com/blog/building-apps-with-sam-typescript-and-vscode-debugging).
 
 I started this project for two reasons:
 

--- a/src/__tests__/__snapshots__/entryFor.test.ts.snap
+++ b/src/__tests__/__snapshots__/entryFor.test.ts.snap
@@ -332,7 +332,7 @@ Object {
 }
 `;
 
-exports[`Function Runtime can be set at the function to nodejs12.x 1`] = `
+exports[`Function Runtime can be set at the function to nodejs14.x 1`] = `
 Object {
   "entryPoints": Object {
     "MyLambda": "./src/my-lambda/app",
@@ -371,7 +371,7 @@ Object {
             "Properties": Object {
               "CodeUri": "MyLambda",
               "Handler": "app.handler",
-              "Runtime": "nodejs12.x",
+              "Runtime": "nodejs14.x",
             },
             "Type": "AWS::Serverless::Function",
           },
@@ -597,7 +597,7 @@ Object {
 }
 `;
 
-exports[`Function Runtime can be set globally to nodejs12.x 1`] = `
+exports[`Function Runtime can be set globally to nodejs14.x 1`] = `
 Object {
   "entryPoints": Object {
     "MyLambda": "./src/my-lambda/app",
@@ -633,7 +633,7 @@ Object {
         "AWSTemplateFormatVersion": "2010-09-09",
         "Globals": Object {
           "Function": Object {
-            "Runtime": "nodejs12.x",
+            "Runtime": "nodejs14.x",
           },
         },
         "Resources": Object {

--- a/src/__tests__/entryFor.test.ts
+++ b/src/__tests__/entryFor.test.ts
@@ -1,7 +1,7 @@
 import SamPlugin from "../index";
 
 describe("Function Runtime", () => {
-  test("can be set globally to nodejs12.x", () => {
+  test("can be set globally to nodejs14.x", () => {
     const plugin = new SamPlugin();
     const template = `
 AWSTemplateFormatVersion: "2010-09-09"
@@ -9,7 +9,7 @@ Transform: AWS::Serverless-2016-10-31
 
 Globals:
   Function:
-    Runtime: nodejs12.x
+    Runtime: nodejs14.x
 
 Resources:
   MyLambda:
@@ -64,7 +64,7 @@ Resources:
     expect(entries).toMatchSnapshot();
   });
 
-  test("can be set at the function to nodejs12.x", () => {
+  test("can be set at the function to nodejs14.x", () => {
     const plugin = new SamPlugin();
     const template = `
 AWSTemplateFormatVersion: "2010-09-09"
@@ -76,7 +76,7 @@ Resources:
     Properties:
       CodeUri: src/my-lambda
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
 `;
     const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
     expect(entries).toMatchSnapshot();
@@ -132,7 +132,7 @@ Resources:
       Handler: app.handler
 `;
     expect(() => plugin.entryFor("default", "", "template.yaml", template, "app")).toThrowError(
-      "MyLambda has an unsupport Runtime. Must be nodejs12.x, nodejs14.x or nodejs16.x"
+      "MyLambda has an unsupport Runtime. Must be nodejs14.x or nodejs16.x"
     );
   });
 
@@ -154,7 +154,7 @@ Resources:
       Handler: app.handler
 `;
     expect(() => plugin.entryFor("default", "", "template.yaml", template, "app")).toThrowError(
-      "MyLambda has an unsupport Runtime. Must be nodejs12.x, nodejs14.x or nodejs16.x"
+      "MyLambda has an unsupport Runtime. Must be nodejs14.x or nodejs16.x"
     );
   });
 
@@ -173,7 +173,7 @@ Resources:
       Runtime: nodejs10.x
 `;
     expect(() => plugin.entryFor("default", "", "template.yaml", template, "app")).toThrowError(
-      "MyLambda has an unsupport Runtime. Must be nodejs12.x, nodejs14.x or nodejs16.x"
+      "MyLambda has an unsupport Runtime. Must be nodejs14.x or nodejs16.x"
     );
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,8 +190,8 @@ class AwsSamPlugin {
         }
 
         // Check the runtime is supported
-        if (!["nodejs12.x", "nodejs14.x", "nodejs16.x"].includes(properties.Runtime ?? defaultRuntime)) {
-          throw new Error(`${resourceKey} has an unsupport Runtime. Must be nodejs12.x, nodejs14.x or nodejs16.x`);
+        if (!["nodejs14.x", "nodejs16.x"].includes(properties.Runtime ?? defaultRuntime)) {
+          throw new Error(`${resourceKey} has an unsupport Runtime. Must be nodejs14.x or nodejs16.x`);
         }
 
         // Continue with a warning if they're using inline code


### PR DESCRIPTION
AWS will no longer support Node.js v12.x on November 1, 2022.

That's why this PR remove it to generate an error if v12 is asked